### PR TITLE
Add tests to Kjokjo rooms.leave

### DIFF
--- a/rocketchat_API/APISections/rooms.py
+++ b/rocketchat_API/APISections/rooms.py
@@ -9,7 +9,7 @@ class RocketChatRooms(RocketChatBase):
     def rooms_leave(self, room_id):
         """Leave room"""
         return self.call_api_post("rooms.leave", roomId=room_id)
-        
+
     def rooms_upload(self, rid, file, **kwargs):
         """Post a message with attached file to a dedicated room."""
         files = {

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -3,6 +3,17 @@ import pytest
 from rocketchat_API.APIExceptions.RocketExceptions import RocketMissingParamException
 
 
+def test_rooms_leave(logged_rocket):
+    # TODO:
+    # Create new room
+    # (optional?) test leaving this room and expect failure bc you are the last owner in the room
+    # create new user
+    # assign new user as owner of this new room
+    # then test leaving the room and expect success
+    rooms_leave = logged_rocket.rooms_leave(room_id="GENERAL").json()
+    assert rooms_leave.get("success")
+
+
 def test_rooms_upload(logged_rocket):
     rooms_upload = logged_rocket.rooms_upload(
         "GENERAL", file="tests/assets/avatar.png", description="hey there"


### PR DESCRIPTION
Hi - I was adding my own code and tests to rocketchat_API and saw [your pull request](https://github.com/jadolg/rocketchat_API/pull/223) just needed some tests.

My head was already in that 'writing tests' space so I added a test for your new function. It is mostly just the test that already existed for test_channels.py:test_channels_leave, but using your new function at the end - so it should be a good enough test.

Oh and I removed some whitespace from right after your function that was causing the linter to throw an error.

All in all, small changes, but hope they help!

